### PR TITLE
Preserve XML Namespaces 

### DIFF
--- a/lib/shale/adapter/nokogiri/node.rb
+++ b/lib/shale/adapter/nokogiri/node.rb
@@ -94,6 +94,10 @@ module Shale
 
           first&.text
         end
+
+        def add_namespace(prefix, namespace)
+          @node.add_namespace(prefix, namespace) if namespace
+        end
       end
     end
   end

--- a/lib/shale/mapping/xml.rb
+++ b/lib/shale/mapping/xml.rb
@@ -95,6 +95,15 @@ module Shale
         @render_nil_default = val
       end
 
+      # Set preserve_namespaces value
+      #
+      # @param [true, false] val
+      #
+      # @api private
+      def preserve_namespaces(val)
+        @preserve_namespaces = val
+      end
+
       # Map group of nodes to mapping methods
       #
       # @param [Symbol] from

--- a/lib/shale/mapping/xml_base.rb
+++ b/lib/shale/mapping/xml_base.rb
@@ -68,6 +68,7 @@ module Shale
         @default_namespace = Descriptor::XmlNamespace.new
         @finalized = false
         @render_nil_default = false
+        @preserve_namespaces = false
       end
 
       # Map element to attribute
@@ -220,6 +221,15 @@ module Shale
       # @api private
       def finalized?
         @finalized
+      end
+
+      # Query the "preserve_namespaces" instance variable
+      #
+      # @return [true false]
+      #
+      # @api private
+      def preserve_namespaces?
+        @preserve_namespaces
       end
 
       # @api private

--- a/spec/features/xml_namespace_definitions_spec.rb
+++ b/spec/features/xml_namespace_definitions_spec.rb
@@ -1,0 +1,116 @@
+# frozen_striing_literal: true
+
+require 'shale'
+require 'shale/adapter/nokogiri'
+
+class Output3 < Shale::Mapper
+  attribute :output4, ::Shale::Type::String
+
+  xml do
+    root 'output3'
+    namespace 'http://ns3.com', "ns1"
+    preserve_namespaces true
+
+    map_element 'output4', to: :output4, namespace: "http://ns3.com", prefix: "ns1"
+  end
+end
+
+class Output2 < Shale::Mapper
+  attribute :output3, ::Output3
+
+  xml do
+    root 'output2'
+    namespace 'http://ns2.com', "ns1"
+    preserve_namespaces true
+
+    map_element 'output3', to: :output3, namespace: "http://ns3.com", prefix: "ns1"
+  end
+end
+
+class PreservingNamespaces < Shale::Mapper
+  attribute :output1, ::Shale::Type::String
+  attribute :output2, ::Output2
+
+  xml do
+    root 'collection'
+    namespace 'http://ns1.com', "ns1"
+
+    map_attribute 'output1', to: :output1
+    map_element 'output2', to: :output2, namespace: "http://ns2.com", prefix: "ns1"
+  end
+end
+
+class NotPreservingOutput3 < Shale::Mapper
+  attribute :output4, ::Shale::Type::String
+
+  xml do
+    root 'output3'
+    namespace 'http://ns3.com', "ns1"
+    preserve_namespaces false
+
+    map_element 'output4', to: :output4, namespace: "http://ns3.com", prefix: "ns1"
+  end
+end
+
+class NotPreservingOutput2 < Shale::Mapper
+  attribute :not_preserving_output3, ::NotPreservingOutput3
+
+  xml do
+    root 'output2'
+    namespace 'http://ns2.com', "ns1"
+
+    map_element 'output3', to: :not_preserving_output3, namespace: "http://ns3.com", prefix: "ns1"
+  end
+end
+
+class NotPreservingNamespaces < Shale::Mapper
+  attribute :output1, ::Shale::Type::String
+  attribute :not_preserving_ouput2, ::NotPreservingOutput2
+
+  xml do
+    root 'collection'
+    namespace 'http://ns1.com', "ns1"
+
+    map_attribute 'output1', to: :output1
+    map_element 'output2', to: :not_preserving_ouput2, namespace: "http://ns2.com", prefix: "ns1"
+  end
+end
+
+RSpec.describe "namespaces with prefixes" do
+  before(:each) do
+    Shale.xml_adapter = ::Shale::Adapter::Nokogiri
+  end
+
+  subject(:xml) do
+    <<~XML
+      <ns1:collection xmlns:ns1="http://ns1.com" output1='A'>
+        <ns1:output2 xmlns:ns1="http://ns2.com">
+          <ns1:output3 xmlns:ns1="http://ns3.com">
+            <ns1:output4>Jhon</ns1:output4>
+          </ns1:output3>
+        </ns1:output2>
+      </ns1:collection>
+    XML
+  end
+
+  describe "preserving namespaces" do
+
+    let(:object) do
+      PreservingNamespaces.from_xml(xml)
+    end
+
+    it "should generate the correct xml" do
+      expect(object.to_xml(pretty: true)).to be_equivalent_to(xml)
+    end
+  end
+
+  describe "not preserving namespaces" do
+    let(:object) do
+      NotPreservingNamespaces.from_xml(xml)
+    end
+
+    it "should generate the correct xml" do
+      expect(object.to_xml(pretty: true)).not_to be_equivalent_to(xml)
+    end
+  end
+end


### PR DESCRIPTION
This PR incorporates an argument for `xml do` block only to preserve namespaces of the child nodes of the elements and not add/replace existing namespaces of the parent element.

closes lutaml/lutaml-model#329 