### PR TITLE
adding option to preserve element ordering

### DIFF
--- a/lib/shale/mapping/xml.rb
+++ b/lib/shale/mapping/xml.rb
@@ -95,6 +95,24 @@ module Shale
         @render_nil_default = val
       end
 
+      # Set preserve_element_order default
+      #
+      # @param [true, false] val
+      #
+      # @api private
+      def preserve_element_order(val)
+        @preserve_element_order = val
+      end
+
+      # Return value for preserve_element_order
+      #
+      # @return [Shale::Mapping::Descriptor::XmlNamespace]
+      #
+      # @api private
+      def preserve_element_order?
+        @preserve_element_order
+      end
+
       # Map group of nodes to mapping methods
       #
       # @param [Symbol] from

--- a/spec/shale/mapping/xml_spec.rb
+++ b/spec/shale/mapping/xml_spec.rb
@@ -370,6 +370,16 @@ RSpec.describe Shale::Mapping::Xml do
     end
   end
 
+  describe '#preserve_element_order' do
+    it 'sets preserve_element_order' do
+      obj = described_class.new
+      expect(obj.preserve_element_order?).to eq(nil)
+
+      obj.preserve_element_order(true)
+      expect(obj.preserve_element_order?).to eq(true)
+    end
+  end
+
   describe '#group' do
     context 'without namespaces' do
       it 'creates methods mappings' do

--- a/spec/shale/type/complex_spec/with_preserve_element_order_spec.rb
+++ b/spec/shale/type/complex_spec/with_preserve_element_order_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'shale'
+require 'shale/error'
+
+require 'shale/adapter/nokogiri'
+
+class WithPreserveOrder < Shale::Mapper
+  attribute :one, Shale::Type::String, collection: true
+  attribute :two, Shale::Type::String, collection: true
+
+  xml do
+    root "with-order-preserve"
+    preserve_element_order true
+
+    map_element 'one', to: :one
+    map_element 'two', to: :two
+  end
+end
+
+class WithoutPreserveOrder < Shale::Mapper
+  attribute :one, Shale::Type::String, collection: true
+  attribute :two, Shale::Type::String, collection: true
+
+  xml do
+    root "without-order-preserve"
+
+    map_element 'one', to: :one
+    map_element 'two', to: :two
+  end
+end
+
+RSpec.describe Shale::Type::Complex do
+  before(:each) do
+    Shale.xml_adapter = Shale::Adapter::Nokogiri
+  end
+
+  context "with preserve order" do
+    let(:xml) do
+      <<~XML.strip
+        <with-order-preserve>
+          <one>aaa</one>
+          <two>bbb</two>
+          <one>ccc</one>
+          <two>ddd</two>
+        </with-order-preserve>
+      XML
+    end
+
+    describe "test element order" do
+      it "should work" do
+        expect(WithPreserveOrder.from_xml(xml).to_xml(pretty: true).strip).to eq(xml)
+      end
+    end
+  end
+
+  context "without preserve order" do
+    describe "test element order" do
+      let(:xml) do
+        <<~XML
+          <without-order-preserve>
+            <one>aaa</one>
+            <two>bbb</two>
+            <one>ccc</one>
+            <two>ddd</two>
+          </without-order-preserve>
+        XML
+      end
+
+      let(:expected_output) do
+        <<~XML.strip
+          <without-order-preserve>
+            <one>aaa</one>
+            <one>ccc</one>
+            <two>bbb</two>
+            <two>ddd</two>
+          </without-order-preserve>
+        XML
+      end
+
+      it "should work" do
+        expect(WithoutPreserveOrder.from_xml(xml).to_xml(pretty: true).strip).to eq(expected_output)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added option `preserve_element_order` to preserve the order of elements when round tripping an xml document.

fixes #2 